### PR TITLE
Example of FieldArray component prop in TypeScript

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -52,6 +52,63 @@ export const MyApp: React.SFC<{}> = () => {
 };
 ```
 
+#### Component props (`<Formik />` and `<FieldArray />`)
+
+```typescript
+import * as React from 'react'
+import { Field, FieldArray, Form, Formik, FormikActions } from 'formik'
+
+interface MyFormValues {
+  friends: string[]
+}
+
+export const FriendList = () => (
+  <div>
+    <h1>Friend List</h1>
+    <Formik
+      initialValues={{
+        friends: ['jared', 'ian', 'brent', 'beau'],
+      }}
+      onSubmit={(
+        values: MyFormValues,
+        actions: FormikActions<MyFormValues>
+      ) => {
+        console.log({ values, actions })
+        alert(JSON.stringify(values, null, 2))
+        actions.setSubmitting(false)
+      }}
+    >
+      {({ isSubmitting }) => (
+        <Form>
+          <FieldArray name="friends" component={FriendsFieldArray} />
+          <button type="submit" disabled={isSubmitting}>
+            Save
+          </button>
+        </Form>
+      )}
+    </Formik>
+  </div>
+)
+
+const FriendsFieldArray = (arrayHelpers: any) => (
+  <div>
+    {arrayHelpers.form.values[arrayHelpers.name].map(
+      (firstName: string, i: number) => (
+        <div key={i}>
+          <label htmlFor={`${arrayHelpers.name}.${i}`}>Friend Name</label>
+          <Field
+            id={`${arrayHelpers.name}.${i}`}
+            name={`${arrayHelpers.name}.${i}`}
+          />
+          <button onClick={() => arrayHelpers.remove(i)}>Remove</button>
+        </div>
+      )
+    )}
+    <button onClick={() => arrayHelpers.push('')}>Add Friend</button>
+  </div>
+)
+```
+
 #### `withFormik()`
 
 ```typescript


### PR DESCRIPTION
This is an example using similar code/content from elsewhere in the docs. 

There is one thing missing from this PR which could use some ❤️ as I was unable to determine the correct value:

- [x] Replace `(arrayHelpers: any)` with the correct type.

I have tried the following without finding one which supports both `name` and `form` array helper values/methods: 
- `ArrayHelpers`
- `FieldArrayRenderProps`
- `FieldArrayConfig`
- `SharedRenderProps<FieldArrayRenderProps>`
- `SharedRenderProps<FieldArrayRenderProps>`

I tried soliciting help on the [Reactiflux Discord #Formik channel](https://discordapp.com/channels/102860784329052160/380509513863921674) but thought I may as well post an example in the docs so that more awesome people can benefit!